### PR TITLE
Save and load agents

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 **/__pycache__/
 AgentParameters
 tokens.py
+learned_weights

--- a/README.md
+++ b/README.md
@@ -1,3 +1,16 @@
-# ConnectFourRL
+# Playing Connect Four with Reinforcement Learning (WIP!)  
 
-Game of connect four with an reinforcement learning agent learning to play the game.
+_NOTE: This repository was initially created as part of an exam project,
+but has recently undergone a major refactoring.  
+Currently, we're in the process of documenting the project and creating
+some templates/examples of how you can extend it and implement
+your own agents and training strategies. If you're interested, please come
+back in a a month or so!_
+
+# Proposed sections for this readme
+
+## Minimal example
+
+_Write a minimal example of how to play the game against a neural network_
+
+## Requirements

--- a/game/Env.py
+++ b/game/Env.py
@@ -41,8 +41,9 @@ class Env():
             - If the user clicks "z", then sets 'display_game' to false, and game will not be shown
 
         Notes for quitting: Learnable parameters are saved using the agents'
-        own procedures for this. The filename indicates that the game was
-        quit, such that users proceed with caution when loading the objects.
+        own methods for this, using default arguments besides the filename.
+        The filename indicates that the game was quit, such that users proceed
+        with caution when loading the objects.
         Optimizer state dicitonaries are not saved.
         Metadata is saved.
         """
@@ -50,12 +51,10 @@ class Env():
         for event in pg.event.get():
             if event.type == pg.QUIT or (event.type == pg.KEYDOWN and event.key == pg.K_ESCAPE):
                 self.player1.save_agent(file_name="on_quit_player1",
-                                        optimizer=None,
-                                        on_quit=True
+                                        optimizer=None
                                         )
                 self.player2.save_agent(file_name="on_quit_player2",
-                                        optimizer=None,
-                                        on_quit=True
+                                        optimizer=None
                                         )
                 pg.quit()
                 sys.exit()

--- a/game/Env.py
+++ b/game/Env.py
@@ -36,14 +36,27 @@ class Env():
         """Function that checks user events
 
         The following events are handled:
-            - If the user clicks escape, or quit, then closes pygame and script
+            - If the user clicks escape, or quit, then saves agents, closes pygame and script
             - If the user clicks "x", then sets 'display_game' to true, and the game will be shown
             - If the user clicks "z", then sets 'display_game' to false, and game will not be shown
+
+        Notes for quitting: Learnable parameters are saved using the agents'
+        own procedures for this. The filename indicates that the game was
+        quit, such that users proceed with caution when loading the objects.
+        Optimizer state dicitonaries are not saved.
+        Metadata is saved.
         """
         pg.init() # if we call pg.display.quit in self.game.close_board() then we also close pygame, so we cant use pg.event.get() after. Therefore, we have to init pg every time
         for event in pg.event.get():
             if event.type == pg.QUIT or (event.type == pg.KEYDOWN and event.key == pg.K_ESCAPE):
-                #TODO: save players before quitting
+                self.player1.save_agent(file_name="on_quit_player1",
+                                        optimizer=None,
+                                        on_quit=True
+                                        )
+                self.player2.save_agent(file_name="on_quit_player2",
+                                        optimizer=None,
+                                        on_quit=True
+                                        )
                 pg.quit()
                 sys.exit()
             if event.type == pg.KEYDOWN and event.key == pg.K_x:

--- a/game/players.py
+++ b/game/players.py
@@ -273,7 +273,7 @@ class DirectPolicyAgent(nn.Module, Player):
                 'Invalid file extension, must be .pt, .pth or not specified.'
                 )
 
-        # check if folder exists as directory
+        # ensure that folder exists prior to saving (torch needs this)
         if not path.isdir(folder):
             mkdir(folder)
         
@@ -296,7 +296,6 @@ class DirectPolicyAgent(nn.Module, Player):
                     f=full_path)
             
         if store_metadata:
-            # create dictionary of metadata
             metadata = {
                 'agent_class_name': self.__class__.__name__,
                 'script_name': path.basename(__file__),
@@ -306,7 +305,6 @@ class DirectPolicyAgent(nn.Module, Player):
                 'neptune_id' : self.neptune_id,
                 'optim_name': optimizer.__class__.__name__
             }
-            # make filename for metadata
             meta_filename = folder + name + '_metadata' + '.json'
             with open(meta_filename, 'w') as write_file:
                 json.dump(metadata, write_file)

--- a/game/players.py
+++ b/game/players.py
@@ -279,7 +279,7 @@ class DirectPolicyAgent(nn.Module, Player):
             mkdir(folder)
         
         # save learnable parameters
-        if not folder.endswith('/'):
+        if not folder.endswith('/') and folder != '':
             folder += '/'
         full_path = folder + file_name
         if not on_quit:

--- a/game/players.py
+++ b/game/players.py
@@ -221,8 +221,7 @@ class DirectPolicyAgent(nn.Module, Player):
 
     def save_agent(self,
                   file_name: str,
-                  optimizer,
-                  on_quit: bool = False,
+                  optimizer=None,
                   folder: str = "learned_weights",
                   store_metadata: bool = True) -> None:
         """Save learnable parameters, optimizer dictionary and metadata.
@@ -231,12 +230,12 @@ class DirectPolicyAgent(nn.Module, Player):
         torch.save(). Overrides Player.save_agent().
         A dictionary is stored at "folder/file_name.pt". It contains:
             - 'model_state_dict': The state_dict of the model, containing
-                current values of learnable parameters.
+                current values of learnable parameters,
             - 'optim_state_dict': The state_dict of the optimizer.
-                (needed for further training)
-                Note: This is left out if argument on_quit is True.
+                (might be needed for further training)
+                Note: This is left out if optimizer=None,
             - 'loss_sum': the current loss, ie. self.stats['loss_sum'].
-                (needed for further training)
+                (needed for further training).
         The model_state_dict can be loaded with self.load_network_weights().
 
         If store_metadata is True, then also stores metadata as .json at
@@ -255,13 +254,13 @@ class DirectPolicyAgent(nn.Module, Player):
                 is not specified, default is ".pt". Both ".pt" and ".pth" are
                 accepted. The metadata file will append "metadata.json" to
                 the provided filename (without extension).
-            optimizer (torch.optim.Optimizer): Current optimizer object.
-            on_quit (bool, optional): Is the function called at quit-event by
-                Env.check_user_events()? Defaults to False.
+            optimizer (torch.optim.Optimizer): Current optimizer object. If
+                None, the optimizer will not be stored. Defaults to None. 
             folder (str, optional): target directory for parameters and
                 metadata, can be "" to store in the same folder as the script
                 calling the function. Defaults to "learned_weights".
-            store_metadata (bool, optional): Also save. Defaults to True.
+            store_metadata (bool, optional): Should metadata be saved?
+                Defaults to True.
 
         Raises:
             ValueError: When user provides a file_name with invalid extension
@@ -282,7 +281,7 @@ class DirectPolicyAgent(nn.Module, Player):
         if not folder.endswith('/') and folder != '':
             folder += '/'
         full_path = folder + file_name
-        if not on_quit:
+        if optimizer:
             torch.save(obj={
                 'model_state_dict': self.state_dict(),
                 'optim_state_dict': optimizer.state_dict(),

--- a/game/players.py
+++ b/game/players.py
@@ -313,6 +313,15 @@ class DirectPolicyAgent(nn.Module, Player):
             
 
     def load_network_weights(self, filepath: str) -> None:
+        """Load network weights stored with self.save_agents().
+
+        self needs to have the same (learnable) structure as the model whose
+        parameters are stored at filepath, but does not need to have anything
+        else in common with the original model.
+
+        Args:
+            filepath (str): Path to the .pt or .pth file to load from
+        """
         self.load_state_dict(torch.load(filepath)['model_state_dict'])
 
 class DirectPolicyAgent_large(DirectPolicyAgent):

--- a/game/players.py
+++ b/game/players.py
@@ -231,11 +231,11 @@ class DirectPolicyAgent(nn.Module, Player):
         torch.save(). Overrides Player.save_agent().
         A dictionary is stored at "folder/file_name.pt". It contains:
             - 'model_state_dict': The state_dict of the model, containing
-                current values of learnable parameters
+                current values of learnable parameters.
             - 'optim_state_dict': The state_dict of the optimizer.
                 (needed for further training)
                 Note: This is left out if argument on_quit is True.
-            - 'loss_sum': the current loss, ie. self.stats['loss_sum']
+            - 'loss_sum': the current loss, ie. self.stats['loss_sum'].
                 (needed for further training)
         The model_state_dict can be loaded with self.load_network_weights().
 
@@ -243,7 +243,10 @@ class DirectPolicyAgent(nn.Module, Player):
         file_name_metadata.json. Included metadata is
             - name of the agent class
             - name of the script invoked to call this function
-            - git . 
+            - current hash of the git repository the script resides in
+            - id of the neptune run used for logging, empty string if not used
+            - name of the optimizer class used, "NoneType" if data is stored
+                upon quitting the environment.
 
         WARNING: The function overwrites existing files without warning.
 

--- a/game/players.py
+++ b/game/players.py
@@ -225,10 +225,43 @@ class DirectPolicyAgent(nn.Module, Player):
                   on_quit: bool = False,
                   folder: str = "learned_weights",
                   store_metadata: bool = True) -> None:
-        # NOTE: default extension is .pt if none is specified in file_name
-    
-        # Make it explicit in the docstring that it overwrites
+        """Save learnable parameters, optimizer dictionary and metadata.
 
+        Save data relevant for inference and resuming training with
+        torch.save(). Overrides Player.save_agent().
+        A dictionary is stored at "folder/file_name.pt". It contains:
+            - 'model_state_dict': The state_dict of the model, containing
+                current values of learnable parameters
+            - 'optim_state_dict': The state_dict of the optimizer.
+                (needed for further training)
+                Note: This is left out if argument on_quit is True.
+            - 'loss_sum': the current loss, ie. self.stats['loss_sum']
+                (needed for further training)
+        The model_state_dict can be loaded with self.load_network_weights().
+
+        If store_metadata is True, then also stores metadata as .json at
+        file_name_metadata.json. Included metadata is
+            - name of the agent class
+            - name of the script invoked to call this function
+            - git . 
+
+        WARNING: The function overwrites existing files without warning.
+
+        Args:
+            file_name (str): name of the file to be stored. If file extension
+                is not specified, default is ".pt". Both ".pt" and ".pth" are
+                accepted. The metadata file will append "metadata.json" to
+                the provided filename (without extension).
+            optimizer (torch.optim.Optimizer): Current optimizer object.
+            on_quit (bool, optional): Is the function called at quit-event by
+                Env.check_user_events()? Defaults to False.
+            folder (str, optional): target directory for parameters and
+                metadata. Defaults to "learned_weights".
+            store_metadata (bool, optional): Also save. Defaults to True.
+
+        Raises:
+            ValueError: When user provides a file_name with invalid extension
+        """
         name, ext = path.splitext(file_name)
         if ext == '':
             file_name += '.pt'

--- a/game/players.py
+++ b/game/players.py
@@ -297,7 +297,9 @@ class DirectPolicyAgent(nn.Module, Player):
             metadata = {
                 'agent_class_name': self.__class__.__name__,
                 'script_name': path.basename(__file__),
-                'current_sha': git.Repo().head.object.hexsha,
+                'current_sha': git.Repo(
+                                        search_parent_directories=True
+                                        ).head.object.hexsha,
                 'neptune_id' : self.neptune_id,
                 'optim_name': optimizer.__class__.__name__
             }

--- a/game/players.py
+++ b/game/players.py
@@ -259,7 +259,8 @@ class DirectPolicyAgent(nn.Module, Player):
             on_quit (bool, optional): Is the function called at quit-event by
                 Env.check_user_events()? Defaults to False.
             folder (str, optional): target directory for parameters and
-                metadata. Defaults to "learned_weights".
+                metadata, can be "" to store in the same folder as the script
+                calling the function. Defaults to "learned_weights".
             store_metadata (bool, optional): Also save. Defaults to True.
 
         Raises:
@@ -274,7 +275,7 @@ class DirectPolicyAgent(nn.Module, Player):
                 )
 
         # ensure that folder exists prior to saving (torch needs this)
-        if not path.isdir(folder):
+        if not path.isdir(folder) and folder != '':
             mkdir(folder)
         
         # save learnable parameters
@@ -311,7 +312,7 @@ class DirectPolicyAgent(nn.Module, Player):
             
 
     def load_network_weights(self, filepath: str) -> None:
-        """Load network weights stored with self.save_agents().
+        """Load network weights (stored with self.save_agents()) to the agent.
 
         self needs to have the same (learnable) structure as the model whose
         parameters are stored at filepath, but does not need to have anything


### PR DESCRIPTION
closes #52 , addresses some of #54

Saves what is necessary for doing inference and for resuming a training. In short, the trained part of the model is saved minimally by use of the `state_dict` functionality in torch. This means that any agent with the same network structure can load the parameters. A similar approach is taken with the optimizer to make resuming of training possible, and to this end, the loss is also stored _(this follows the general approach mentioned here: https://github.com/RasmusBrostroem/ConnectFourRL/issues/52#issuecomment-1325446243)._

## Implements
This PR implements `DirectPolicyAgent.save_agent()`, `DirectPolicyAgent.load_network_weights()` and also modifies `Env.check_user_events()` to make sure that model is saved in case of quitting the environment by mistake(see #54). Moreover, these methods are added to the parent `Player` class to ensure we can always call them on a player.  
See the documentation of the methods for further details.

`learned_weights` are added to the `.gitignore`, since this is the default folder for `save_agents()`. I liked this name better than `AgentParameters`.

Finally, I've written a short note and a couple of proposed sections for the `README.md`.

### Comments
The saving function currently needs the optimizer as input (just like `update_agent()` does) since the optimizer isn't directly accessible from within the agent object, but instead is a part of the training script running the agent. This feels kind of awkward, and we could consider changing it in the future.  
This also gave some problems related to saving when the user quits the environment. For now, the state_dict of the optimizer is not saved in this case. This means that quitting will only save the `state_dict` of the model and the model's current loss along with the `file_name_metadata.json`, in which 'optim_name' will always be `"NoneType"`.
I chose this approach in order to not make it overly complicated.


#### Not stored
Some parts mentioned in https://github.com/RasmusBrostroem/ConnectFourRL/issues/52#issuecomment-1325446243 is not being stored.  
Aside from the current loss, nothing from the log is being stored to disk. I decided to assume that users will always use neptune for logging (if they want to log), therefore it is redundant and unnecessary to also store this information on disk.  
I've also chosen to not store the number of epochs/generations, as it is a) not directly accessible by the agent and b) not strictly necessary for resuming training.    
If an user does not use neptune, they'll have to figure out how to log by themselves.


#### Not implemented
Loading the metadata, the optimizer state dict and the loss is not implemented. This needs to be implemented directly where relevant in training scripts/evaluation scripts, and should not be part of the agents themselves. 


One thing mentioned in #54 which is not addressed here is the cleaning of attributes, which I have not implemented.  
For the time being, the user needs to be cautious when loading on-quit objects. So the question is if we are satisfied with this implementation to the extent that we wish to close #54. 
We could let #54 remain open, if you think - one way to address it down the road would be to add a reset/clean-method to DirectPolicyAgent classes. What do you think? 

## Next up
I suggest that we merge refactor-project into main after this PR has been approved, since we are done with the refactoring (besides documentation).