### PR TITLE
Use any reward for update

### DIFF
--- a/game/Env.py
+++ b/game/Env.py
@@ -122,7 +122,8 @@ class Env():
         """
 
         if self.currentPlayer.training:
-            self.currentPlayer.incremental_update(game=self.game)
+            self.currentPlayer.incremental_update(game=self.game,
+                                                  terminal_state=False)
 
         # Making current player select an action
         col_choice = self.currentPlayer.select_action(game=self.game,
@@ -177,12 +178,14 @@ class Env():
                 self.player2.calculate_rewards()
                 if self.player1.training:
                     self.player1.update_stats()
-                    self.player1.incremental_update(game=self.game)
+                    self.player1.incremental_update(game=self.game,
+                                                    terminal_state=True)
                 else:
                     self.player1.update_benchmark_stats()
                 if self.player2.training:
                     self.player2.update_stats()
-                    self.player2.incremental_update(game=self.game)
+                    self.player2.incremental_update(game=self.game,
+                                                    terminal_state=True)
                 else:
                     self.player2.update_benchmark_stats()
                 if self.display_game:
@@ -211,7 +214,8 @@ class Env():
             if done:
                 self.player1.update_stats()
                 if self.player1.training:
-                    self.player1.incremental_update(game=self.game)
+                    self.player1.incremental_update(game=self.game,
+                                                    terminal_state=True)
                 if self.display_game:
                     self.render(delay=self.params.win_screen_delay)
                 break

--- a/game/players.py
+++ b/game/players.py
@@ -939,8 +939,7 @@ class TDAgent(DirectPolicyAgent):
             best_move (int): Column index of the chosen move.
         """
         if self.rewards:
-            reward = self.params["win_reward"]\
-                if self.rewards[-1] == self.params["win_reward"] else 0
+            reward = self.rewards[-1]
         else:
             reward = 0
 

--- a/game/players.py
+++ b/game/players.py
@@ -352,7 +352,9 @@ class Player():
         """
         return self.train(mode=False)
 
-    def incremental_update(self, game: connect_four) -> None:
+    def incremental_update(self,
+                           game: connect_four,
+                           terminal_state: bool) -> None:
         """Placeholder function.
 
         Returns:
@@ -930,7 +932,8 @@ class TDAgent(DirectPolicyAgent):
         del self.rewards[:]
 
     def incremental_update(self,
-                           game: connect_four) -> None:
+                           game: connect_four,
+                           terminal_state: bool) -> None:
         """Update network with the fully incremental update rule.
 
         Args:
@@ -971,8 +974,7 @@ class TDAgent(DirectPolicyAgent):
                 + param.grad
 
         # clean-up?
-        if self.rewards \
-                and self.rewards[-1] != self.params["not_ended_reward"]:
+        if terminal_state:
             self.zero_eligibility()
             self.last_v_hat = torch.zeros((1))
             del self.rewards[:]


### PR DESCRIPTION
closes #97 
Changed `incremental_update()` such that it always uses the last appended reward (except at t<sub>0</sub>).

Also added the argument `terminal_state`. This was done to prevent a possible bug with the old check for clean-up. In the special case where not_ended_reward is not unique (e.g. equal to tie_reward) the clean-up would initiate prematurely.