### PR TITLE
Make TDAgent hyperparameters configurable

### DIFF
--- a/game/players.py
+++ b/game/players.py
@@ -116,6 +116,8 @@ class Player():
             "illegal_reward": -5,
             "not_ended_reward": 0,
             "gamma": 0.8,
+            "alpha": 0.1,
+            "Lambda": 1,
             "device": "cpu",
             "training": True
         }
@@ -154,6 +156,8 @@ class Player():
         self.saved_log_probs = []
         self.rewards = []
         self.gamma = self.params["gamma"]
+        self.alpha = self.params["alpha"]
+        self.Lambda = self.params["Lambda"]
         self.training = self.params["training"]
 
     def select_action(self,
@@ -831,11 +835,6 @@ class TDAgent(DirectPolicyAgent):
 
         # attributes for update
         self.last_v_hat = torch.zeros((1))
-
-        # hyperparameters for update rule
-        self.gamma = 0.9
-        self.Lambda = 1
-        self.alpha = 0.1
 
     def zero_eligibility(self):
         for name, param in self.named_parameters():


### PR DESCRIPTION
Moved the hardcoded hyperparameters from the `__init__` of `TDAgent` to the one in `Player` such that they can be passed to all Player classes as `kwargs`.